### PR TITLE
Fix ag installation on ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ if [[ ! -x $(which ag) ]]; then
   fi
 
   working -n "Installing ag"
-  log_cmd ag $INSTALL || fail "ag install failed. Check logs at $LOG_DIR"
+  log_cmd ag "$INSTALL" || fail "ag install failed. Check logs at $LOG_DIR"
 fi
 
 finish


### PR DESCRIPTION
On Ubuntu, installing ag didn't work and logged "[task-logger] Option -y doesn't exists for log_cmd".
Putting command between quotes fixes the issue, although I don't have a Mac to try it on.
